### PR TITLE
fix(docker): use Docker Engine API for accurate image sizes and add jazzy variants

### DIFF
--- a/.github/workflows/docker-image-size.yaml
+++ b/.github/workflows/docker-image-size.yaml
@@ -12,15 +12,20 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5
+        with:
+          set-host: true
+
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository (main)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Git user's name and email
         run: |
@@ -39,29 +44,41 @@ jobs:
           fi
 
       - name: Checkout data branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: data-storage
           path: data-storage
 
+      - name: Check available disk space
+        id: disk-space
+        run: |
+          df -h /
+          avail_gb=$(df --output=avail / | tail -1 | awk '{printf "%d", $1/1024/1024}')
+          echo "available_gb=$avail_gb" >> "$GITHUB_OUTPUT"
+
       - name: Free Disk Space (Ubuntu)
+        if: steps.disk-space.outputs.available_gb < 40
         uses: jlumbroso/free-disk-space@main
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests
+        run: pip install requests
 
       - name: Execute script
         run: |
           python scripts/docker_image_size.py \
             --output-dir data-storage \
             --github-token ${{ github.token }}
+
+      - name: Disk space and image sizes after script
+        run: |
+          df -h /
+          docker image ls
+          docker version
 
       - name: Check and commit results
         run: |

--- a/.github/workflows/docker-image-size.yaml
+++ b/.github/workflows/docker-image-size.yaml
@@ -57,7 +57,7 @@ jobs:
           echo "available_gb=$avail_gb" >> "$GITHUB_OUTPUT"
 
       - name: Free Disk Space (Ubuntu)
-        if: steps.disk-space.outputs.available_gb < 40
+        if: steps.disk-space.outputs.available_gb < 80
         uses: jlumbroso/free-disk-space@main
 
       - name: Set up Python

--- a/.github/workflows/measure_workflows.yaml
+++ b/.github/workflows/measure_workflows.yaml
@@ -18,7 +18,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Git user's name and email
         run: |
@@ -37,23 +37,21 @@ jobs:
           fi
 
       - name: Checkout data branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: data-storage
           path: data-storage
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests numpy
+        run: pip install requests numpy
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: cache
           key: actions
@@ -67,9 +65,9 @@ jobs:
           cp github_action_data.json public/
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: public/
 
       - name: Publish
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/public/index.html
+++ b/public/index.html
@@ -29,17 +29,17 @@
         </a>
       </p>
 
-      <h2>health-check execution times</h2>
-      <div id="health-check-time-chart"></div>
-
-      <h2>docker-build-and-push execution times</h2>
-      <div id="docker-build-and-push-time-chart"></div>
+      <h2>Docker image sizes (uncompressed)</h2>
+      <div id="docker-chart-uncompressed"></div>
 
       <h2>Docker image sizes (compressed)</h2>
       <div id="docker-chart-compressed"></div>
 
-      <h2>Docker image sizes (uncompressed)</h2>
-      <div id="docker-chart-uncompressed"></div>
+      <h2>docker-build-and-push execution times</h2>
+      <div id="docker-build-and-push-time-chart"></div>
+
+      <h2>health-check execution times</h2>
+      <div id="health-check-time-chart"></div>
     </div>
     <script src="./main.js"></script>
   </body>

--- a/public/main.js
+++ b/public/main.js
@@ -187,7 +187,7 @@ fetch('github_action_data.json')
     const dockerCompressedOptions = {
       series: Object.entries(dockerCompressedData).map(([name, data]) => ({
         name,
-        data: data.map((d) => [new Date(d.date), d.size_compressed / 1024 / 1024 / 1024]),
+        data: data.map((d) => [new Date(d.date), d.size_compressed / 1000 / 1000 / 1000]),
       })),
       chart: {
         height: 500,
@@ -253,7 +253,7 @@ fetch('github_action_data.json')
     const dockerUncompressedOptions = {
       series: Object.entries(dockerUncompressedData).map(([name, data]) => ({
         name,
-        data: data.map((d) => [new Date(d.date), d.size_uncompressed / 1024 / 1024 / 1024]),
+        data: data.map((d) => [new Date(d.date), d.size_uncompressed / 1000 / 1000 / 1000]),
       })),
       chart: {
         height: 500,

--- a/public/main.js
+++ b/public/main.js
@@ -176,32 +176,19 @@ fetch('github_action_data.json')
 
     // Docker image size chart (compressed)
     const dockerCompressedData = {
-      'core-devel': json.docker_images['core-devel'],
-      'universe-devel': json.docker_images['universe-devel'],
-      'universe-devel-cuda': json.docker_images['universe-devel-cuda'],
+      'core-devel': json.docker_images['core-devel'] || [],
+      'core-devel-jazzy': json.docker_images['core-devel-jazzy'] || [],
+      'universe-devel': json.docker_images['universe-devel'] || [],
+      'universe-devel-jazzy': json.docker_images['universe-devel-jazzy'] || [],
+      'universe-devel-cuda': json.docker_images['universe-devel-cuda'] || [],
+      'universe-devel-jazzy-cuda': json.docker_images['universe-devel-jazzy-cuda'] || [],
     };
 
     const dockerCompressedOptions = {
-      series: [
-        {
-          name: 'core-devel',
-          data: json.docker_images['core-devel'].map((data) => {
-            return [new Date(data.date), data.size_compressed / 1024 / 1024 / 1024];
-          }),
-        },
-        {
-          name: 'universe-devel',
-          data: json.docker_images['universe-devel'].map((data) => {
-            return [new Date(data.date), data.size_compressed / 1024 / 1024 / 1024];
-          }),
-        },
-        {
-          name: 'universe-devel-cuda',
-          data: json.docker_images['universe-devel-cuda'].map((data) => {
-            return [new Date(data.date), data.size_compressed / 1024 / 1024 / 1024];
-          }),
-        },
-      ],
+      series: Object.entries(dockerCompressedData).map(([name, data]) => ({
+        name,
+        data: data.map((d) => [new Date(d.date), d.size_compressed / 1024 / 1024 / 1024]),
+      })),
       chart: {
         height: 500,
         type: 'line',
@@ -255,32 +242,19 @@ fetch('github_action_data.json')
 
     // Docker image size chart (uncompressed)
     const dockerUncompressedData = {
-      'core-devel': json.docker_images['core-devel'],
-      'universe-devel': json.docker_images['universe-devel'],
-      'universe-devel-cuda': json.docker_images['universe-devel-cuda'],
+      'core-devel': json.docker_images['core-devel'] || [],
+      'core-devel-jazzy': json.docker_images['core-devel-jazzy'] || [],
+      'universe-devel': json.docker_images['universe-devel'] || [],
+      'universe-devel-jazzy': json.docker_images['universe-devel-jazzy'] || [],
+      'universe-devel-cuda': json.docker_images['universe-devel-cuda'] || [],
+      'universe-devel-jazzy-cuda': json.docker_images['universe-devel-jazzy-cuda'] || [],
     };
 
     const dockerUncompressedOptions = {
-      series: [
-        {
-          name: 'core-devel',
-          data: json.docker_images['core-devel'].map((data) => {
-            return [new Date(data.date), data.size_uncompressed / 1024 / 1024 / 1024];
-          }),
-        },
-        {
-          name: 'universe-devel',
-          data: json.docker_images['universe-devel'].map((data) => {
-            return [new Date(data.date), data.size_uncompressed / 1024 / 1024 / 1024];
-          }),
-        },
-        {
-          name: 'universe-devel-cuda',
-          data: json.docker_images['universe-devel-cuda'].map((data) => {
-            return [new Date(data.date), data.size_uncompressed / 1024 / 1024 / 1024];
-          }),
-        },
-      ],
+      series: Object.entries(dockerUncompressedData).map(([name, data]) => ({
+        name,
+        data: data.map((d) => [new Date(d.date), d.size_uncompressed / 1024 / 1024 / 1024]),
+      })),
       chart: {
         height: 500,
         type: 'line',

--- a/scripts/docker_image_size.py
+++ b/scripts/docker_image_size.py
@@ -1,17 +1,22 @@
 import argparse
+import functools
+import http.client
 import json
 import os
 import pathlib
+import socket
 from datetime import datetime, timezone
 
 import requests
 from subprocess import run, PIPE
 
+print = functools.partial(print, flush=True)
+
 REGISTRY = "ghcr.io"
 REGISTRY_URL = f"http://{REGISTRY}"
 ORG = "autowarefoundation"
 IMAGE = "autoware"
-TAGS = ["universe-devel", "universe-devel-cuda", "core-devel"]
+TAGS = ["core-devel", "universe-devel", "universe-devel-cuda"]
 OUTPUT_DIR = "data/docker_image_sizes"
 OUTPUT_FILE_TEMPLATE = "docker_image_sizes_{timestamp}.json"
 
@@ -114,8 +119,32 @@ def get_compressed_size(image: str, tag: str, token: str) -> tuple[int, int, str
         return 0, 0, ""
 
 
+def get_image_disk_usage(image_ref: str) -> int:
+    """Get the on-disk size of a Docker image via the Docker Engine API.
+
+    Queries /images/json which returns accurate disk usage in raw bytes,
+    unlike 'docker inspect' whose Size field varies across storage backends.
+    Reads the DOCKER_HOST env var for the socket path.
+    """
+    docker_host = os.environ.get("DOCKER_HOST", "unix:///var/run/docker.sock")
+    sock_path = docker_host.replace("unix://", "")
+    try:
+        conn = http.client.HTTPConnection("localhost")
+        conn.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        conn.sock.connect(sock_path)
+        conn.request("GET", "/v1.47/images/json")
+        resp = conn.getresponse()
+        for img in json.loads(resp.read()):
+            tags = img.get("RepoTags") or []
+            if image_ref in tags:
+                return img.get("Size", 0)
+    except Exception as e:
+        print(f"Warning: Failed to query Docker Engine API at {sock_path}: {e}")
+    return 0
+
+
 def get_uncompressed_size(image: str, tag: str) -> int:
-    """Get the uncompressed size of a Docker image by pulling it.
+    """Get the uncompressed (on-disk) size of a Docker image by pulling it.
 
     Tries docker first, falls back to podman if docker is not available.
     Returns size in bytes, or 0 if unable to determine.
@@ -132,7 +161,7 @@ def get_uncompressed_size(image: str, tag: str) -> int:
 
             # Pull the image
             pull_result = run(
-                [cmd, "pull", "--platform", "linux/amd64", image_ref],
+                [cmd, "pull", "--quiet", "--platform", "linux/amd64", image_ref],
                 stdout=PIPE,
                 stderr=PIPE,
                 text=True,
@@ -142,40 +171,14 @@ def get_uncompressed_size(image: str, tag: str) -> int:
                 print(f"Warning: Failed to pull image with {cmd}: {pull_result.stderr}")
                 continue
 
-            # Get image size using inspect
-            inspect_result = run(
-                [cmd, "inspect", image_ref],
-                stdout=PIPE,
-                stderr=PIPE,
-                timeout=30,
-                text=True,
-            )
+            # Get on-disk size via Docker Engine API
+            size = get_image_disk_usage(image_ref)
 
-            remove_result = run(
-                [cmd, "system", "prune", "--all", "--force"],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
+            if size > 0:
+                print(f"Uncompressed size for {image_ref}: {size} bytes")
+                return size
 
-            if inspect_result.returncode != 0:
-                print(
-                    f"Warning: Failed to inspect image with {cmd}: {inspect_result.stderr}"
-                )
-                continue
-
-            inspect_data = json.loads(inspect_result.stdout)
-            if not inspect_data:
-                continue
-
-            # Get Size field (uncompressed size)
-            size = inspect_data[0].get("Size", 0)
-
-            # Clean up the image
-            run([cmd, "rmi", image_ref], stdout=PIPE, stderr=PIPE, timeout=30)
-
-            print(f"Uncompressed size for {image_ref}: {size} bytes")
-            return size
+            print(f"Warning: Could not find {image_ref} in Docker Engine API output")
 
         except Exception as e:
             print(f"Warning: Error with {cmd}: {e}")

--- a/scripts/docker_image_size.py
+++ b/scripts/docker_image_size.py
@@ -209,9 +209,9 @@ def get_image_size(token: str, tag: str) -> dict:
         return {
             "tag": tag,
             "compressed_size_bytes": compressed_size,
-            "compressed_size_gb": round(compressed_size / (1024**3), 2),
+            "compressed_size_gb": round(compressed_size / (1000**3), 2),
             "uncompressed_size_bytes": uncompressed_size,
-            "uncompressed_size_gb": round(uncompressed_size / (1024**3), 2),
+            "uncompressed_size_gb": round(uncompressed_size / (1000**3), 2),
             "num_layers": num_layers,
             "digest": digest,
             "fetched_at": (datetime.now(timezone.utc).isoformat()),

--- a/scripts/docker_image_size.py
+++ b/scripts/docker_image_size.py
@@ -16,7 +16,14 @@ REGISTRY = "ghcr.io"
 REGISTRY_URL = f"http://{REGISTRY}"
 ORG = "autowarefoundation"
 IMAGE = "autoware"
-TAGS = ["core-devel", "universe-devel", "universe-devel-cuda"]
+TAGS = [
+    "core-devel",
+    "universe-devel",
+    "universe-devel-cuda",
+    "core-devel-jazzy",
+    "universe-devel-jazzy",
+    "universe-devel-jazzy-cuda",
+]
 OUTPUT_DIR = "data/docker_image_sizes"
 OUTPUT_FILE_TEMPLATE = "docker_image_sizes_{timestamp}.json"
 

--- a/scripts/measure_workflows.py
+++ b/scripts/measure_workflows.py
@@ -71,6 +71,9 @@ def get_docker_image_analysis_from_data(date_threshold, data_dir=DATA_DIR):
         "core-devel": [],
         "universe-devel": [],
         "universe-devel-cuda": [],
+        "core-devel-jazzy": [],
+        "universe-devel-jazzy": [],
+        "universe-devel-jazzy-cuda": [],
     }
 
     # Find all JSON files in the data directory

--- a/scripts/measure_workflows.py
+++ b/scripts/measure_workflows.py
@@ -1,7 +1,10 @@
 import argparse
+import functools
 import json
 import pathlib
 from datetime import datetime, timedelta, timezone
+
+print = functools.partial(print, flush=True)
 
 import github_api
 from colcon_log_analyzer import ColconLogAnalyzer
@@ -197,11 +200,19 @@ if __name__ == "__main__":
     github_token = args.github_token
 
     date_threshold = datetime.now(timezone.utc) - timedelta(days=90)
+    print(f"Fetching workflow runs since {date_threshold.date()}")
     (
         health_check,
         docker_build_and_push,
     ) = get_workflow_runs(github_token, date_threshold)
+    print(f"  health-check: {len(health_check)} runs")
+    print(f"  docker-build-and-push: {len(docker_build_and_push)} runs")
+
+    print(f"Loading docker image data from {args.data_dir}")
     docker_images = get_docker_image_analysis_from_data(date_threshold, args.data_dir)
+    for tag, entries in docker_images.items():
+        print(f"  {tag}: {len(entries)} data points")
+
     json_data = export_to_json(
         health_check,
         docker_build_and_push,
@@ -210,3 +221,4 @@ if __name__ == "__main__":
 
     with open("github_action_data.json", "w") as jsonfile:
         json.dump(json_data, jsonfile, indent=4)
+    print(f"Wrote github_action_data.json")


### PR DESCRIPTION
## Summary
- Replace `docker inspect` with Docker Engine API `/images/json` for accurate
  uncompressed image sizes — `docker inspect` Size field is unreliable across
  storage backends (compressed on containerd snapshotter, partial on overlay2)
- Add `docker/setup-docker-action@v5` for consistent Docker version in CI
- Read `DOCKER_HOST` env var to support custom socket paths
- Track jazzy image variants: `core-devel-jazzy`, `universe-devel-jazzy`,
  `universe-devel-jazzy-cuda`
- Bump free disk space threshold from 40 GB to 80 GB
- Fix GB/GiB mismatch: use base-1000 (GB) consistently
- Suppress `docker pull` layer progress with `--quiet`
- Bump action versions (checkout v6, setup-python v6, login-action v4, etc.)
- Add progress logging to `measure_workflows.py`
- Reorder dashboard to show Docker image sizes first

## Test runs
- https://github.com/autowarefoundation/autoware-ci-metrics/actions/runs/24290259782
- https://github.com/autowarefoundation/autoware-ci-metrics/actions/runs/24290959697

## Before

<img width="984" height="420" alt="image" src="https://github.com/user-attachments/assets/ddaf3112-ca88-4e4a-b0e5-a7375875ea2e" />

`universe-devel-cuda` size is measured as `22GiB` (`23.63GB`) (The `GiB` / `GB` fix is applied in this PR.)

## After

<img width="996" height="420" alt="image" src="https://github.com/user-attachments/assets/6bf08d4b-5bd6-4962-b019-d6ea8a1e5e5d" />

The same `universe-devel-cuda` size is measured as `36.44GB`

Also `universe-devel-jazzy-cuda` is `37.14GB`.